### PR TITLE
Refactor: shaders folder structor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://github.com/olivierlacan/keep-a
 ### Changed
 
 - Use yarn workspace for `three`, `js-base64` and `pako` packages. (https://github.com/yushiang-demo/PanoToMesh/pull/41)
+- Refactor shader folder structure. (https://github.com/yushiang-demo/pano-to-mesh/pull/44)
 
 ### Fixed
 

--- a/packages/three/shaders/fragmentShaders/cubemapToEquirectangular.js
+++ b/packages/three/shaders/fragmentShaders/cubemapToEquirectangular.js
@@ -1,10 +1,3 @@
-export const setUniforms = (material, { cubeTexture }) => {
-  if (!material.uniforms.cubeTexture) {
-    material.uniforms.cubeTexture = {};
-  }
-  material.uniforms.cubeTexture.value = cubeTexture;
-};
-
 const shader = `
 precision mediump float;
 uniform samplerCube cubeTexture;

--- a/packages/three/shaders/fragmentShaders/dilation.js
+++ b/packages/three/shaders/fragmentShaders/dilation.js
@@ -1,10 +1,3 @@
-export const setUniforms = (material, { kernel }) => {
-  if (!material.uniforms.kernel) {
-    material.uniforms.kernel = {};
-  }
-  material.uniforms.kernel.value = kernel;
-};
-
 const shader = `
 uniform sampler2D texture0;
 uniform int kernel;

--- a/packages/three/shaders/fragmentShaders/equirectangularProjection.js
+++ b/packages/three/shaders/fragmentShaders/equirectangularProjection.js
@@ -1,16 +1,3 @@
-import * as THREE from "three";
-
-export const setUniforms = (material, { texture, cameraPosition }) => {
-  if (!material.uniforms.tEquirect) {
-    material.uniforms.tEquirect = {};
-    material.uniforms.camerasPosition = new THREE.Vector3();
-  }
-
-  material.uniforms.tEquirect.value = texture;
-  material.uniforms.tEquirect.value.minFilter = THREE.LinearFilter;
-  material.uniforms.camerasPosition.value = cameraPosition;
-};
-
 const shader = `
 #define M_PI 3.14159
 uniform sampler2D tEquirect;

--- a/packages/three/shaders/fragmentShaders/hoverEffect.js
+++ b/packages/three/shaders/fragmentShaders/hoverEffect.js
@@ -1,14 +1,3 @@
-import * as THREE from "three";
-
-export const setUniforms = (material, { map, mouse }) => {
-  if (!material.uniforms.map) {
-    material.uniforms.map = {};
-    material.uniforms.mouse = new THREE.Vector2();
-  }
-  material.uniforms.map.value = map;
-  material.uniforms.mouse.value = mouse;
-};
-
 const shader = `
 uniform sampler2D map;
 uniform vec2 mouse;

--- a/packages/three/shaders/fragmentShaders/index.js
+++ b/packages/three/shaders/fragmentShaders/index.js
@@ -1,0 +1,10 @@
+export { default as cubemapToEquirectangular } from "./cubemapToEquirectangular";
+export { default as edgeDetection } from "./edgeDetection";
+export { default as dilation } from "./dilation";
+export { default as textureBoundary } from "./textureBoundary";
+export { default as vertexColor } from "./vertexColor";
+export { default as equirectangularProjection } from "./equirectangularProjection";
+export { default as faceNormal } from "./faceNormal";
+export { default as textureBlending } from "./textureBlending";
+export { default as texture } from "./texture";
+export { default as hoverEffect } from "./hoverEffect";

--- a/packages/three/shaders/fragmentShaders/texture.js
+++ b/packages/three/shaders/fragmentShaders/texture.js
@@ -1,10 +1,3 @@
-export const setUniforms = (material, { map }) => {
-  if (!material.uniforms.map) {
-    material.uniforms.map = {};
-  }
-  material.uniforms.map.value = map;
-};
-
 const shader = `
 uniform sampler2D map;
 varying vec2 vUv;

--- a/packages/three/shaders/fragmentShaders/textureBlending.js
+++ b/packages/three/shaders/fragmentShaders/textureBlending.js
@@ -1,14 +1,3 @@
-export const setUniforms = (material, { texture0, texture1, percentage }) => {
-  if (!material.uniforms.texture0) {
-    material.uniforms.texture0 = {};
-    material.uniforms.texture1 = {};
-    material.uniforms.percentage = {};
-  }
-  material.uniforms.texture0.value = texture0;
-  material.uniforms.texture1.value = texture1;
-  material.uniforms.percentage.value = percentage;
-};
-
 const shader = `
 uniform sampler2D texture0;
 uniform sampler2D texture1;

--- a/packages/three/shaders/index.js
+++ b/packages/three/shaders/index.js
@@ -1,51 +1,11 @@
-import cubemapToEquirectangular, {
-  setUniforms as cubemapToEquirectangularUniforms,
-} from "./fragmentShaders/cubemapToEquirectangular";
-import edgeDetection from "./fragmentShaders/edgeDetection";
-import dilation, {
-  setUniforms as dilationUniforms,
-} from "./fragmentShaders/dilation";
-import textureBoundary from "./fragmentShaders/textureBoundary";
-import vertexColor from "./fragmentShaders/vertexColor";
-import equirectangularProjection, {
-  setUniforms as equirectangularProjectionUniforms,
-} from "./fragmentShaders/equirectangularProjection";
-import faceNormal from "./fragmentShaders/faceNormal";
-import textureBlending, {
-  setUniforms as textureBlendingUniforms,
-} from "./fragmentShaders/textureBlending";
-import texture, {
-  setUniforms as textureUniforms,
-} from "./fragmentShaders/texture";
-import hoverEffect, {
-  setUniforms as hoverEffectUniforms,
-} from "./fragmentShaders/hoverEffect";
-import screenPosition from "./vertexShaders/screenPosition";
-import worldPosition from "./vertexShaders/worldPosition";
-import uvPosition from "./vertexShaders/uvPosition";
+import * as fragmentShaders from "./fragmentShaders";
+import * as vertexShaders from "./vertexShaders";
+import * as setUniforms from "./uniforms";
 
 const Shaders = {
-  vertexShaders: { worldPosition, screenPosition, uvPosition },
-  fragmentShaders: {
-    vertexColor,
-    edgeDetection,
-    dilation,
-    faceNormal,
-    texture,
-    textureBlending,
-    textureBoundary,
-    equirectangularProjection,
-    cubemapToEquirectangular,
-    hoverEffect,
-  },
-  setUniforms: {
-    equirectangularProjection: equirectangularProjectionUniforms,
-    cubemapToEquirectangular: cubemapToEquirectangularUniforms,
-    texture: textureUniforms,
-    textureBlending: textureBlendingUniforms,
-    dilation: dilationUniforms,
-    hoverEffect: hoverEffectUniforms,
-  },
+  vertexShaders,
+  fragmentShaders,
+  setUniforms,
 };
 
 export default Shaders;

--- a/packages/three/shaders/uniforms/cubemapToEquirectangular.js
+++ b/packages/three/shaders/uniforms/cubemapToEquirectangular.js
@@ -1,0 +1,8 @@
+const setUniforms = (material, { cubeTexture }) => {
+  if (!material.uniforms.cubeTexture) {
+    material.uniforms.cubeTexture = {};
+  }
+  material.uniforms.cubeTexture.value = cubeTexture;
+};
+
+export default setUniforms;

--- a/packages/three/shaders/uniforms/dilation.js
+++ b/packages/three/shaders/uniforms/dilation.js
@@ -1,0 +1,8 @@
+const setUniforms = (material, { kernel }) => {
+  if (!material.uniforms.kernel) {
+    material.uniforms.kernel = {};
+  }
+  material.uniforms.kernel.value = kernel;
+};
+
+export default setUniforms;

--- a/packages/three/shaders/uniforms/equirectangularProjection.js
+++ b/packages/three/shaders/uniforms/equirectangularProjection.js
@@ -1,0 +1,14 @@
+import * as THREE from "three";
+
+const setUniforms = (material, { texture, cameraPosition }) => {
+  if (!material.uniforms.tEquirect) {
+    material.uniforms.tEquirect = {};
+    material.uniforms.camerasPosition = new THREE.Vector3();
+  }
+
+  material.uniforms.tEquirect.value = texture;
+  material.uniforms.tEquirect.value.minFilter = THREE.LinearFilter;
+  material.uniforms.camerasPosition.value = cameraPosition;
+};
+
+export default setUniforms;

--- a/packages/three/shaders/uniforms/hoverEffect.js
+++ b/packages/three/shaders/uniforms/hoverEffect.js
@@ -1,0 +1,12 @@
+import * as THREE from "three";
+
+const setUniforms = (material, { map, mouse }) => {
+  if (!material.uniforms.map) {
+    material.uniforms.map = {};
+    material.uniforms.mouse = new THREE.Vector2();
+  }
+  material.uniforms.map.value = map;
+  material.uniforms.mouse.value = mouse;
+};
+
+export default setUniforms;

--- a/packages/three/shaders/uniforms/index.js
+++ b/packages/three/shaders/uniforms/index.js
@@ -1,0 +1,6 @@
+export { default as cubemapToEquirectangular } from "./cubemapToEquirectangular";
+export { default as dilation } from "./dilation";
+export { default as equirectangularProjection } from "./equirectangularProjection";
+export { default as textureBlending } from "./textureBlending";
+export { default as texture } from "./texture";
+export { default as hoverEffect } from "./hoverEffect";

--- a/packages/three/shaders/uniforms/texture.js
+++ b/packages/three/shaders/uniforms/texture.js
@@ -1,0 +1,8 @@
+const setUniforms = (material, { map }) => {
+  if (!material.uniforms.map) {
+    material.uniforms.map = {};
+  }
+  material.uniforms.map.value = map;
+};
+
+export default setUniforms;

--- a/packages/three/shaders/uniforms/textureBlending.js
+++ b/packages/three/shaders/uniforms/textureBlending.js
@@ -1,0 +1,12 @@
+const setUniforms = (material, { texture0, texture1, percentage }) => {
+  if (!material.uniforms.texture0) {
+    material.uniforms.texture0 = {};
+    material.uniforms.texture1 = {};
+    material.uniforms.percentage = {};
+  }
+  material.uniforms.texture0.value = texture0;
+  material.uniforms.texture1.value = texture1;
+  material.uniforms.percentage.value = percentage;
+};
+
+export default setUniforms;

--- a/packages/three/shaders/vertexShaders/index.js
+++ b/packages/three/shaders/vertexShaders/index.js
@@ -1,0 +1,3 @@
+export { default as screenPosition } from "./screenPosition";
+export { default as worldPosition } from "./worldPosition";
+export { default as uvPosition } from "./uvPosition";


### PR DESCRIPTION
### Changed

- Move `setUniforms` from fragmentShader folder to  uniforms folder.
- Enhance import export syntax of shader