### PR TITLE
Refactor: three/core export route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://github.com/olivierlacan/keep-a
 
 - Use yarn workspace for `three`, `js-base64` and `pako` packages. (https://github.com/yushiang-demo/PanoToMesh/pull/41)
 - Refactor shader folder structure. (https://github.com/yushiang-demo/pano-to-mesh/pull/44)
+- Refactor three/core export route structure. (https://github.com/yushiang-demo/pano-to-mesh/pull/47)
 
 ### Fixed
 

--- a/packages/three/components/PanoramaOutline/index.js
+++ b/packages/three/components/PanoramaOutline/index.js
@@ -1,9 +1,7 @@
 import { useEffect, useState } from "react";
 import * as THREE from "three";
 
-import CapturePanorama from "../../core/CapturePanorama";
-import { create3DRoom } from "../../core/RoomGeometry";
-import TexturePostEffect from "../../core/TexturePostEffect";
+import { CapturePanorama, create3DRoom, TexturePostEffect } from "../../core";
 import Shaders from "../../shaders";
 
 const ROOM_TEXTURE_WIDTH = 1920;

--- a/packages/three/components/PanoramaProjectionMesh/index.js
+++ b/packages/three/components/PanoramaProjectionMesh/index.js
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import * as THREE from "three";
 
-import { create3DRoom } from "../../core/RoomGeometry";
+import { create3DRoom } from "../../core";
 import Shaders from "../../shaders";
 import { RENDER_ORDER } from "../../constant";
 

--- a/packages/three/components/PanoramaTextureMesh/index.js
+++ b/packages/three/components/PanoramaTextureMesh/index.js
@@ -1,10 +1,8 @@
 import { forwardRef, useEffect, useState } from "react";
 import * as THREE from "three";
 
-import { create3DRoom } from "../../core/RoomGeometry";
+import { create3DRoom, TexturePostEffect, exportTexture } from "../../core";
 import Shaders from "../../shaders";
-import TexturePostEffect from "../../core/TexturePostEffect";
-import { exportTexture } from "../../core/helpers/Texture";
 import { RENDER_ORDER } from "../../constant";
 
 const TEXTURE_SIZE = 4096;

--- a/packages/three/components/ThreeCanvas/index.js
+++ b/packages/three/components/ThreeCanvas/index.js
@@ -1,7 +1,6 @@
 import React, { forwardRef, useEffect, useRef, useState } from "react";
 
-import Css3D from "../../core/Css3D";
-import Three from "../../core";
+import { Css3D, Three } from "../../core";
 
 const monitorStyle = {
   position: "absolute",

--- a/packages/three/core/index.js
+++ b/packages/three/core/index.js
@@ -1,65 +1,11 @@
-import * as THREE from "three";
-import CameraControls from "./helpers/CameraControls";
+export { default as Math } from "./helpers/Math";
+export { raycastGeometry, raycastMeshFromScreen } from "./helpers/Raycaster";
+export { getEmptyRoomGeometry, downloadMesh } from "./RoomGeometry";
 
-function Three({ canvas, alpha = true, interactElement }) {
-  const { width, height } = canvas.getBoundingClientRect();
+export { default as CapturePanorama } from "./CapturePanorama";
+export { create3DRoom } from "./RoomGeometry";
+export { default as TexturePostEffect } from "./TexturePostEffect";
+export { exportTexture } from "./helpers/Texture";
 
-  const scene = new THREE.Scene();
-  const renderer = new THREE.WebGLRenderer({
-    canvas,
-    alpha,
-    preserveDrawingBuffer: true,
-  });
-  renderer.setSize(width, height);
-
-  const camera = new THREE.PerspectiveCamera(75, width / height, 0.01, 1000);
-  const cameraControls = new CameraControls(camera, interactElement);
-
-  const customRender = {};
-  const animate = () => {
-    const animeFrame = requestAnimationFrame(animate);
-    Object.keys(customRender)
-      .map((key) => customRender[key])
-      .forEach((func) => func(renderer));
-    renderer.render(scene, camera);
-
-    return animeFrame;
-  };
-
-  const animeFrame = animate();
-
-  const destroy = () => {
-    cancelAnimationFrame(animeFrame);
-    cameraControls.destroy();
-  };
-
-  const setCanvasSize = (width, height) => {
-    camera.aspect = width / height;
-    camera.updateProjectionMatrix();
-    renderer.setSize(width, height);
-  };
-
-  const addBeforeRenderFunction = (func) => {
-    let id = THREE.MathUtils.generateUUID();
-
-    while (customRender[id] !== undefined) {
-      id = THREE.MathUtils.generateUUID();
-    }
-
-    customRender[id] = func;
-    return () => {
-      delete customRender[id];
-    };
-  };
-
-  return {
-    destroy,
-    setCanvasSize,
-    scene,
-    addBeforeRenderFunction,
-    renderer,
-    cameraControls,
-  };
-}
-
-export default Three;
+export { default as Three } from "./three";
+export { default as Css3D } from "./Css3D";

--- a/packages/three/core/three.js
+++ b/packages/three/core/three.js
@@ -1,0 +1,65 @@
+import * as THREE from "three";
+import CameraControls from "./helpers/CameraControls";
+
+function Three({ canvas, alpha = true, interactElement }) {
+  const { width, height } = canvas.getBoundingClientRect();
+
+  const scene = new THREE.Scene();
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    alpha,
+    preserveDrawingBuffer: true,
+  });
+  renderer.setSize(width, height);
+
+  const camera = new THREE.PerspectiveCamera(75, width / height, 0.01, 1000);
+  const cameraControls = new CameraControls(camera, interactElement);
+
+  const customRender = {};
+  const animate = () => {
+    const animeFrame = requestAnimationFrame(animate);
+    Object.keys(customRender)
+      .map((key) => customRender[key])
+      .forEach((func) => func(renderer));
+    renderer.render(scene, camera);
+
+    return animeFrame;
+  };
+
+  const animeFrame = animate();
+
+  const destroy = () => {
+    cancelAnimationFrame(animeFrame);
+    cameraControls.destroy();
+  };
+
+  const setCanvasSize = (width, height) => {
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, height);
+  };
+
+  const addBeforeRenderFunction = (func) => {
+    let id = THREE.MathUtils.generateUUID();
+
+    while (customRender[id] !== undefined) {
+      id = THREE.MathUtils.generateUUID();
+    }
+
+    customRender[id] = func;
+    return () => {
+      delete customRender[id];
+    };
+  };
+
+  return {
+    destroy,
+    setCanvasSize,
+    scene,
+    addBeforeRenderFunction,
+    renderer,
+    cameraControls,
+  };
+}
+
+export default Three;

--- a/packages/three/index.js
+++ b/packages/three/index.js
@@ -8,20 +8,7 @@ export { default as Css3DObject } from "./components/Css3DObject";
 export { default as TransformControls } from "./components/TransformControls";
 export { TRANSFORM_CONTROLS_MODE } from "./components/TransformControls";
 export { default as MeshIndexMap } from "./components/MeshIndexMap";
+
 export * as Placeholder from "./components/Placeholder";
 export * as Media from "./helpers/MediaLoader";
-
-import Math from "./core/helpers/Math";
-import {
-  raycastGeometry,
-  raycastMeshFromScreen,
-} from "./core/helpers/Raycaster";
-import { getEmptyRoomGeometry, downloadMesh } from "./core/RoomGeometry";
-
-export const Core = {
-  Math,
-  raycastGeometry,
-  raycastMeshFromScreen,
-  getEmptyRoomGeometry,
-  downloadMesh,
-};
+export * as Core from "./core";


### PR DESCRIPTION
## Changed

- Refactor core export from root `index.js`

### After

![image](https://github.com/yushiang-demo/pano-to-mesh/assets/27216619/507ccdda-5394-4b15-beb0-c05ee9ae0719)

### Before

![image](https://github.com/yushiang-demo/pano-to-mesh/assets/27216619/aa79e082-91ed-494e-a061-768bff66f1ee)
