### PR TITLE
Refactor: add objectSeletor for MeshIndexMap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ The format is based on [Keep a Changelog](https://github.com/olivierlacan/keep-a
 
 ### Fixed
 
+- Fix `MeshIndexMap` update single mesh make everything re-render. (https://github.com/yushiang-demo/pano-to-mesh/pull/52)
+
 ### Removed
+
+- Rename `addBeforeRenderFunction` to `addBeforeRenderEvent`. (https://github.com/yushiang-demo/pano-to-mesh/pull/52)
 
 ## [1.3.0] - 2023-10-08
 

--- a/components/ObjectSelector/index.js
+++ b/components/ObjectSelector/index.js
@@ -1,0 +1,69 @@
+import { useState, useEffect, forwardRef, useMemo } from "react";
+
+import { Media, MeshIndexMap } from "@pano-to-mesh/three";
+import { MEDIA_2D, MEDIA_3D } from "../MediaManager/types";
+
+const Mesh = ({ type, data, transformation, onLoad }) => {
+  const [mesh, setMesh] = useState(null);
+  useEffect(() => {
+    const getMesh = async (type) => {
+      if (type === MEDIA_3D.PLACEHOLDER_3D) {
+        return Media.getBoxMesh();
+      } else if (type === MEDIA_3D.MODAL) {
+        return await Media.getModal(data.src);
+      } else if (Object.values(MEDIA_2D).includes(type)) {
+        return Media.getPlaneMesh();
+      }
+    };
+
+    getMesh(type).then(setMesh);
+  }, [type, data]);
+
+  useEffect(() => {
+    if (!mesh) return;
+    mesh.setTransform(transformation);
+    onLoad(mesh);
+  }, [mesh, transformation, onLoad]);
+
+  return null;
+};
+
+const ObjectSelector = ({ media, mouse, ...props }, ref) => {
+  const [raycasterMeshes, setRaycasterMeshes] = useState([]);
+
+  const onLoad = useMemo(
+    () =>
+      media.map((_, idx) => {
+        return (mesh) => {
+          setRaycasterMeshes((prev) => {
+            const copy = [...prev];
+            copy[idx] = mesh;
+            return copy;
+          });
+        };
+      }),
+    [media]
+  );
+
+  return (
+    <>
+      {media.map((data, index) => (
+        <Mesh
+          key={index}
+          type={data.type}
+          data={data.data}
+          transformation={data.transformation}
+          onLoad={onLoad[index]}
+        />
+      ))}
+      <MeshIndexMap
+        meshes={raycasterMeshes}
+        mouse={mouse}
+        ref={ref}
+        {...props}
+      />
+    </>
+  );
+};
+
+export default forwardRef(ObjectSelector);

--- a/packages/three/components/PanoramaOutline/index.js
+++ b/packages/three/components/PanoramaOutline/index.js
@@ -17,7 +17,7 @@ const PanoramaOutline = ({
   const [mesh, setMesh] = useState(null);
   const [panoramaCapturer, setPanoramaCapturer] = useState(null);
   useEffect(() => {
-    const { scene, addBeforeRenderFunction } = three;
+    const { scene, addBeforeRenderEvent } = three;
 
     const setupScene = () => {
       const panoramaScene = new THREE.Scene();
@@ -43,7 +43,7 @@ const PanoramaOutline = ({
     );
     setPanoramaCapturer(panoramaCapturer);
 
-    const stopCapturePanorama = addBeforeRenderFunction((renderer) => {
+    const stopCapturePanorama = addBeforeRenderEvent((renderer) => {
       panoramaCapturer.render(renderer);
     });
 
@@ -55,7 +55,7 @@ const PanoramaOutline = ({
       panoramaCapturer.texture,
       Shaders.fragmentShaders.edgeDetection
     );
-    const stopTexturePostEffect = addBeforeRenderFunction(renderOutline);
+    const stopTexturePostEffect = addBeforeRenderEvent(renderOutline);
 
     const geometry1 = new THREE.PlaneGeometry(1, 1);
     const material1 = new THREE.ShaderMaterial({

--- a/packages/three/components/PanoramaTextureMesh/index.js
+++ b/packages/three/components/PanoramaTextureMesh/index.js
@@ -21,7 +21,7 @@ const PanoramaTextureMesh = (
   }, [frameBuffer]);
 
   useEffect(() => {
-    const { scene, addBeforeRenderFunction, renderer } = three;
+    const { scene, addBeforeRenderEvent, renderer } = three;
 
     const geometry = create3DRoom(layout2D, ceilingY, floorY);
 
@@ -47,7 +47,7 @@ const PanoramaTextureMesh = (
         renderer.setRenderTarget(null);
       };
 
-      const stopRenderTexture = addBeforeRenderFunction(render);
+      const stopRenderTexture = addBeforeRenderEvent(render);
 
       const dispose = () => {
         stopRenderTexture();
@@ -65,7 +65,7 @@ const PanoramaTextureMesh = (
       dispose: disposeTexturePostEffect,
       material: dilationMaterial,
     } = TexturePostEffect(texture, Shaders.fragmentShaders.dilation);
-    const stopTexturePostEffect = addBeforeRenderFunction(renderDilatedTexture);
+    const stopTexturePostEffect = addBeforeRenderEvent(renderDilatedTexture);
     Shaders.setUniforms.dilation(dilationMaterial, {
       kernel: 5,
     });

--- a/packages/three/components/ThreeCanvas/index.js
+++ b/packages/three/components/ThreeCanvas/index.js
@@ -42,7 +42,7 @@ const ThreeCanvas = (
       destroy,
       setCanvasSize,
       scene,
-      addBeforeRenderFunction,
+      addBeforeRenderEvent,
       renderer,
       cameraControls,
     } = new Three({
@@ -55,13 +55,13 @@ const ThreeCanvas = (
       camera: cameraControls.getCamera(),
     });
 
-    const stopRenderCss3D = addBeforeRenderFunction(() => {
+    const stopRenderCss3D = addBeforeRenderEvent(() => {
       css3DControls.render();
     });
 
     const publicProps = {
       scene,
-      addBeforeRenderFunction,
+      addBeforeRenderEvent,
       renderer,
       cameraControls,
       css3DControls,
@@ -69,14 +69,14 @@ const ThreeCanvas = (
 
     setThree(publicProps);
 
-    const cancelResizeListener = addBeforeRenderFunction(() => {
+    const cancelResizeListener = addBeforeRenderEvent(() => {
       const { clientWidth: width, clientHeight: height } = WrapperRef.current;
       setCanvasSize(width, height);
       css3DControls.setSize(width, height);
     });
 
     const stopMonitorMemory = dev
-      ? addBeforeRenderFunction((renderer) => {
+      ? addBeforeRenderEvent((renderer) => {
           const displayObject = renderer.info.memory;
           const jsonText = JSON.stringify(displayObject, null, 4);
 

--- a/packages/three/core/three.js
+++ b/packages/three/core/three.js
@@ -39,24 +39,28 @@ function Three({ canvas, alpha = true, interactElement }) {
     renderer.setSize(width, height);
   };
 
-  const addBeforeRenderFunction = (func) => {
-    let id = THREE.MathUtils.generateUUID();
+  const getEventRegister = (funcs) => {
+    return (func) => {
+      let id = THREE.MathUtils.generateUUID();
 
-    while (customRender[id] !== undefined) {
-      id = THREE.MathUtils.generateUUID();
-    }
+      while (funcs[id] !== undefined) {
+        id = THREE.MathUtils.generateUUID();
+      }
 
-    customRender[id] = func;
-    return () => {
-      delete customRender[id];
+      funcs[id] = func;
+      return () => {
+        delete funcs[id];
+      };
     };
   };
+
+  const addBeforeRenderEvent = getEventRegister(customRender);
 
   return {
     destroy,
     setCanvasSize,
     scene,
-    addBeforeRenderFunction,
+    addBeforeRenderEvent,
     renderer,
     cameraControls,
   };

--- a/packages/three/shaders/uniforms/hoverEffect.js
+++ b/packages/three/shaders/uniforms/hoverEffect.js
@@ -3,10 +3,21 @@ import * as THREE from "three";
 const setUniforms = (material, { map, mouse }) => {
   if (!material.uniforms.map) {
     material.uniforms.map = {};
+  }
+
+  if (!material.uniforms.mouse) {
     material.uniforms.mouse = new THREE.Vector2();
   }
-  material.uniforms.map.value = map;
-  material.uniforms.mouse.value = mouse;
+
+  if (map) {
+    const oldTexture = material.uniforms.map.value;
+    material.uniforms.map.value = map;
+    oldTexture?.dispose();
+  }
+
+  if (mouse) {
+    material.uniforms.mouse.value = mouse;
+  }
 };
 
 export default setUniforms;


### PR DESCRIPTION
### Changed

- Fix mesh reload issue cause by react component re-render.
- Refactor `MeshIndexMap` set mouse uniforms independently for better performance.
- Refactor rename `addBeforeRenderFunction` to `addBeforeRenderEvent`.