### PR TITLE
Fix: cant select text in float menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://github.com/olivierlacan/keep-a
 
 - Fix `MeshIndexMap` update single mesh make everything re-render. (https://github.com/yushiang-demo/pano-to-mesh/pull/52) (https://github.com/yushiang-demo/pano-to-mesh/pull/53)
 
+- Fix textbox in floating menu with `react-rnd` can't select whole text. (https://github.com/yushiang-demo/pano-to-mesh/pull/54)
+
 ### Removed
 
 - Rename `addBeforeRenderFunction` to `addBeforeRenderEvent`. (https://github.com/yushiang-demo/pano-to-mesh/pull/52)

--- a/components/PropertySettings/URLInput/index.js
+++ b/components/PropertySettings/URLInput/index.js
@@ -23,7 +23,11 @@ const URLInput = ({ data, onChange }) => {
 
   return (
     <Wrapper>
-      <Input value={url} onChange={onType} />
+      <Input
+        value={url}
+        onChange={onType}
+        onMouseDown={(e) => e.stopPropagation()}
+      />
       <RowWrapper>
         <Button onClick={onCancel}> Cancel</Button>
         <Button onClick={onSave}> Save</Button>


### PR DESCRIPTION
### Changed

- Add `onMouseDown={(e) => e.stopPropagation()} ` to children of `react-rnd` to make interactions works.


### Reference

https://github.com/bokuweb/react-rnd/issues/403#issuecomment-408855306