### PR TITLE
Fix: support mobile touch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ The format is based on [Keep a Changelog](https://github.com/olivierlacan/keep-a
 
 - Fix textbox in floating menu with `react-rnd` can't select whole text. (https://github.com/yushiang-demo/pano-to-mesh/pull/54)
 
+- Fix textbox in floating menu with `react-rnd` can't select whole text. (https://github.com/yushiang-demo/pano-to-mesh/pull/54)
+- Fix editor supports touch events on mobile devices. (https://github.com/yushiang-demo/pano-to-mesh/pull/59)
+
 ### Removed
 
 - Rename `addBeforeRenderFunction` to `addBeforeRenderEvent`. (https://github.com/yushiang-demo/pano-to-mesh/pull/52)
+- Remove `react-rnd` package for floating tool box. (https://github.com/yushiang-demo/pano-to-mesh/pull/59)
 
 ## [1.3.0] - 2023-10-08
 

--- a/components/PropertySettings/ModelSettings/index.js
+++ b/components/PropertySettings/ModelSettings/index.js
@@ -24,7 +24,6 @@ const ModelSettings = ({ data, onChange }) => {
         step={1e-3}
         value={data.time}
         onChange={onChangeTime}
-        onMouseDown={(e) => e.stopPropagation()}
       />
     </>
   );

--- a/components/PropertySettings/URLInput/index.js
+++ b/components/PropertySettings/URLInput/index.js
@@ -23,11 +23,7 @@ const URLInput = ({ data, onChange }) => {
 
   return (
     <Wrapper>
-      <Input
-        value={url}
-        onChange={onType}
-        onMouseDown={(e) => e.stopPropagation()}
-      />
+      <Input value={url} onChange={onType} />
       <RowWrapper>
         <Button onClick={onCancel}> Cancel</Button>
         <Button onClick={onSave}> Save</Button>

--- a/components/ToolbarRnd/index.js
+++ b/components/ToolbarRnd/index.js
@@ -1,35 +1,16 @@
-import { Rnd } from "react-rnd";
 import { styled } from "styled-components";
 
 const Wrapper = styled.div`
-  width: 100%;
-  height: 100%;
+  position: fixed;
+  z-index: 999;
+  top: 0;
   background: #e2e2e2;
   border-radius: 5px;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
 `;
 
 const ToolbarRnd = ({ children }) => {
-  return (
-    <Rnd
-      default={{
-        x: 10,
-        y: 10,
-      }}
-      enableResizing={{
-        top: false,
-        right: false,
-        bottom: false,
-        left: false,
-        topRight: false,
-        bottomRight: false,
-        bottomLeft: false,
-        topLeft: false,
-      }}
-    >
-      <Wrapper>{children}</Wrapper>
-    </Rnd>
-  );
+  return <Wrapper>{children}</Wrapper>;
 };
 
 export default ToolbarRnd;

--- a/hooks/useClick2AddWalls.js
+++ b/hooks/useClick2AddWalls.js
@@ -59,24 +59,9 @@ const useClick2AddWalls = ({
     setPreviewImageCoord(null);
     setDragging(false);
   };
-  const onMouseMove = ({ normalizedX, normalizedY, width, height }) => {
+  const onMouseMove = ({ normalizedX, normalizedY }) => {
     if (dragging && parseMousePointTo3D([normalizedX, normalizedY]))
       setPreviewImageCoord([normalizedX, normalizedY]);
-    else {
-      const point = imageCoord.find(
-        pointSelector(
-          normalizedX,
-          normalizedY,
-          ({ x, y }) => ({
-            x: x * width,
-            y: y * height,
-          }),
-          selectThresholdPixel
-        )
-      );
-      if (point) document.body.style.cursor = "move";
-      else document.body.style.cursor = "copy";
-    }
   };
 
   const onMouseUp = ({ normalizedX, normalizedY }) => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-rnd": "^10.4.1",
     "styled-components": "^6.0.4",
     "uuid": "^9.0.0"
   },

--- a/packages/three/components/ThreeCanvas/index.js
+++ b/packages/three/components/ThreeCanvas/index.js
@@ -136,9 +136,9 @@ const ThreeCanvas = (
     <div
       ref={WrapperRef}
       style={WrapperStyle}
-      onMouseDown={handleMouseEvents(onMouseDown)}
-      onMouseMove={handleMouseEvents(onMouseMove)}
-      onMouseUp={handleMouseEvents(onMouseUp)}
+      onPointerDown={handleMouseEvents(onMouseDown)}
+      onPointerMove={handleMouseEvents(onMouseMove)}
+      onPointerUp={handleMouseEvents(onMouseUp)}
     >
       {dev && <pre style={monitorStyle}>{monitor}</pre>}
       <div ref={css3DWrapperRef} style={Css3DContainerStyle} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,11 +1865,6 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
-clsx@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
-
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -2340,11 +2335,6 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-
-fast-memoize@^2.5.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
-  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -3193,13 +3183,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-re-resizable@6.9.6:
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.6.tgz#b95d37e3821481b56ddfb1e12862940a791e827d"
-  integrity sha512-0xYKS5+Z0zk+vICQlcZW+g54CcJTTmHluA7JUUgvERDxnKAnytylcyPsA+BSFi759s5hPlHmBRegFrwXs2FuBQ==
-  dependencies:
-    fast-memoize "^2.5.1"
-
 react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -3208,27 +3191,10 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-draggable@4.4.5:
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.5.tgz#9e37fe7ce1a4cf843030f521a0a4cc41886d7e7c"
-  integrity sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==
-  dependencies:
-    clsx "^1.1.1"
-    prop-types "^15.8.1"
-
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-rnd@^10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/react-rnd/-/react-rnd-10.4.1.tgz#9e1c3f244895d7862ef03be98b2a620848c3fba1"
-  integrity sha512-0m887AjQZr6p2ADLNnipquqsDq4XJu/uqVqI3zuoGD19tRm6uB83HmZWydtkilNp5EWsOHbLGF4IjWMdd5du8Q==
-  dependencies:
-    re-resizable "6.9.6"
-    react-draggable "4.4.5"
-    tslib "2.3.1"
 
 react@18.2.0:
   version "18.2.0"
@@ -3601,11 +3567,6 @@ tsconfig-paths@^3.14.2:
     json5 "^1.0.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
-
-tslib@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@^2.4.0, tslib@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
### Changed

- Support mobile touch events.
- Remove `react-rnd` avoid element events blocked.
- Replace `onMouseDown` with `onPointerDown`.